### PR TITLE
chore(secrets): add SOPS config + env template

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - path_regex: '^infra/secrets/.*\.sops(\.env|\.yaml|\.json)$'
+    # Replace this with your *publicage* age key, e.g. age1q2W3e4r5t6...
+    age:
+      - "REPLACE_WITH_AGE_PUBLIC_KEY"

--- a/infra/secrets/.env.template
+++ b/infra/secrets/.env.template
@@ -1,0 +1,5 @@
+# copy to .env locally, then encrypt to .env.sops with SOPS
+ENGINE_MCP_SSE_URL=https://mcp-stub-server-production.up.railway.app/sse
+ENGINE_LOG_LEVEL=INFO
+# ENGINE_MCP_HTTP_URL=   # optional when you deploy HTTP MCP
+# ENGINE_MCP_TOKEN= # optional if your MCP is protected


### PR DESCRIPTION
Adds `.sops.yaml` (age) and `infra/secrets/.env.template` for encrypted secrets via SOPS.

Next: add AGE public key, encrypt `.env` to `.env.sops`, and wire CI to set Railway variables + redeploy.