### PR TITLE
feat(engine): fix engine_server.py; add Procfile and requirements.txt; SSE optional; health endpoints

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn engine.engine_server:app --host 0.0.0.0 --port ${PORT:-8080}

--- a/engine/engine_server.py
+++ b/engine/engine_server.py
@@ -1,6 +1,25 @@
-from fastapi import FastAPI, HJSONResponse
+import os, logging
+from fastapi import FastAPI
+
 app = FastAPI()
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
 
 @app.get("/engine/ready")
 def ready():
- Return 200 JSON: {"status":"ok"}, JSONResponse.OK 
+    return {"status": "ok"}
+
+def start_sse_if_configured():
+    url = os.getenv("ENGINE_MCP_SSE_URL")
+    if not url:
+        logging.warning("ENGINE_MCP_SSE_URL not set; continuing without SSE.")
+        return
+    try:
+        # TODO: implement SSE client or remove if unused
+        pass
+    except Exception as e:
+        logging.exception("SSE loop error: %s", e)
+
+start_sse_if_configured()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
This PR fixes a crash caused by invalid syntax in engine/engine_server.py by replacing prose with valid FastAPI code, adds /healthz and /engine/ready endpoints, and makes SSE optional (no crash if ENGINE_MCP_SSE_URL is unset). It also adds a Procfile and requirements.txt for clean Railway deploys.

Start command: 

    uvicorn engine.engine_server:app --host 0.0.0.0 --port $PORT

Railway envs: ensure PORT=8080. Leave ENGINE_MCP_SSE_URL unset if not used.

Testing: open /healthz after deploy; should return {"status":"ok"}.